### PR TITLE
manual pre-generation: separate .etex files from stdlib build

### DIFF
--- a/manual/Makefile
+++ b/manual/Makefile
@@ -15,8 +15,12 @@ release:
 tools:
 	cd tools; ${MAKE} clean; ${MAKE} all
 
-# The pregen target generates the latex files from the .etex files
-# and the ocamldoc documentation for the standard library to ensure
-# that at least this phase of the manual build process is correct
+# The pregen-etex target generates the latex files from the .etex
+# files to ensure that this phase of the manual build process, which
+# may execute OCaml fragments and expect certain outputs, is correct
+pregen-etex: tools
+	cd manual; $(MAKE) etex-files
+
+# pregen builds both .etex files and the documentation of the standard library
 pregen: tools
-	cd manual; ${MAKE} files
+	cd manual; $(MAKE) files

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -92,6 +92,12 @@ text: files
 	         -I ../tutorials -I ../../styles -I ../texstuff \
 	         ../manual.inf -e macros.tex ../manual.tex
 
+etex-files: $(FILES)
+	cd refman; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd library; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd cmds; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd tutorials; $(MAKE) etex-files RELEASEDIR=$(SRC)
+
 files: $(FILES)
 	cd refman; $(MAKE) all RELEASEDIR=$(SRC)
 	cd library; $(MAKE) all RELEASEDIR=$(SRC)

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -9,6 +9,7 @@ TRANSF=$(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 
+etex-files: $(FILES)
 all: $(FILES)
 
 clean::

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -49,6 +49,7 @@ CSLDIR=$(RELEASEDIR)
 
 VPATH=.:$(CSLDIR)/stdlib:$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
 
+etex-files: $(BLURB)
 all: libs
 	./check-stdlib-modules $(CSLDIR)
 

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -11,6 +11,7 @@ TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
 
+etex-files: $(ALLFILES)
 all: $(ALLFILES)
 
 clean:

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -8,6 +8,7 @@ TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
 
+etex-files: $(ALLFILES)
 all: $(ALLFILES)
 
 clean:


### PR DESCRIPTION
We introduce a `pregen-etex` Makefile rule that only build the .etex
files of the manual (whose OCaml examples may be tested and expected
to produce certain outputs), without also building the
standard-library documentation. This is faster than the previous
`pregen` rule as ocamldoc on the standard library was the
bottleneck. On my machine, `pregen-etex` completes in 1.5s-2s, while
`pregen` completes in 6s-7s.
