### PR TITLE
Use functors in Diffing, instead of too many parameters

### DIFF
--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -545,7 +545,7 @@ module Variant_diffing = struct
               cd1.cd_res cd2.cd_res cd1.cd_args cd2.cd_args with
       | Some reason ->
           Error (Diffing_with_keys.Type {pos; got=cd1; expected=cd2; reason})
-      | None -> Ok (Ident.name cd1.cd_id)
+      | None -> Ok ()
 
   let diffing loc env params1 params2 cstrs_1 cstrs_2 =
     let test = test loc env params1 params2 in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -135,7 +135,8 @@ type label_mismatch =
   | Mutability of position
 
 type record_change =
-  (Types.label_declaration, label_mismatch) Diffing_with_keys.change
+  (Types.label_declaration, Types.label_declaration, label_mismatch)
+    Diffing_with_keys.change
 
 type record_mismatch =
   | Label_mismatch of record_change list
@@ -167,7 +168,7 @@ type private_object_mismatch =
   | Types of Env.t * Errortrace.comparison Errortrace.t
 
 type variant_change =
-  (Types.constructor_declaration, constructor_mismatch)
+  (Types.constructor_declaration, Types.constructor_declaration, constructor_mismatch)
     Diffing_with_keys.change
 
 type type_mismatch =
@@ -415,7 +416,9 @@ module Record_diffing = struct
         if t.types_match then 10 else 15
     | Diffing.Change _ -> 10
 
-  let key (x: Types.label_declaration) = Ident.name x.ld_id
+  let name (x: Types.label_declaration) = Ident.name x.ld_id
+  let key = (name, name)
+
   let diffing loc env params1 params2 cstrs_1 cstrs_2 =
     let test = test loc env in
     let cstrs_1 = Diffing_with_keys.with_pos cstrs_1 in
@@ -558,7 +561,8 @@ module Variant_diffing = struct
       (Array.of_list cstrs_1)
       (Array.of_list cstrs_2)
     in
-    let key (x:Types.constructor_declaration) = Ident.name x.cd_id in
+    let name (x:Types.constructor_declaration) = Ident.name x.cd_id in
+    let key = (name, name) in
     Diffing_with_keys.refine ~key ~update ~test () raw
 
   let compare ~loc env params1 params2 l r =

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -40,7 +40,7 @@ type label_mismatch =
   | Mutability of position
 
 type record_change =
-  (Types.label_declaration, Types.label_declaration, label_mismatch) Diffing_with_keys.change
+  (Types.label_declaration, Types.label_declaration, label_mismatch) Diffing_with_keys.keyed_change
 
 type record_mismatch =
   | Label_mismatch of record_change list
@@ -61,7 +61,7 @@ type extension_constructor_mismatch =
                             * constructor_mismatch
 type variant_change =
   (Types.constructor_declaration, Types.constructor_declaration, constructor_mismatch)
-    Diffing_with_keys.change
+    Diffing_with_keys.keyed_change
 
 type private_variant_mismatch =
   | Openness

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -40,7 +40,7 @@ type label_mismatch =
   | Mutability of position
 
 type record_change =
-  (Types.label_declaration, label_mismatch) Diffing_with_keys.change
+  (Types.label_declaration, Types.label_declaration, label_mismatch) Diffing_with_keys.change
 
 type record_mismatch =
   | Label_mismatch of record_change list
@@ -60,7 +60,7 @@ type extension_constructor_mismatch =
                             * extension_constructor
                             * constructor_mismatch
 type variant_change =
-  (Types.constructor_declaration, constructor_mismatch)
+  (Types.constructor_declaration, Types.constructor_declaration, constructor_mismatch)
     Diffing_with_keys.change
 
 type private_variant_mismatch =

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -848,8 +848,8 @@ module Functor_inclusion_diff = struct
 
   let expand_params state  =
     match lookup_expansion state with
-    | None -> state, None, None
-    | Some (res, expansion) -> { state with res }, Some expansion, None
+    | None -> state, None
+    | Some (res, expansion) -> { state with res }, Some expansion
 
   let update d st =
     let open Diffing in
@@ -859,7 +859,7 @@ module Functor_inclusion_diff = struct
     | Keep (Unit,_,_)
     | Keep (_,Unit,_)
     | Change (_,(Unit | Named (None,_)), _) ->
-        st, None, None
+        st, None
     | Insert (Named (Some id, arg))
     | Delete (Named (Some id, arg))
     | Change (Unit, Named (Some id, arg), _) ->
@@ -876,12 +876,12 @@ module Functor_inclusion_diff = struct
             expand_params { st with env; subst }
         | None, Some id2 ->
             let env = Env.add_module id2 Mp_present arg' st.env in
-            { st with env }, None, None
+            { st with env }, None
         | Some id1, None ->
             let env = Env.add_module id1 Mp_present arg' st.env in
             expand_params { st with env }
         | None, None ->
-            st, None, None
+            st, None
       end
 
   let test st mty1 mty2 =
@@ -893,7 +893,7 @@ module Functor_inclusion_diff = struct
 
   end
 
-  module Diff = Diffing.Make(Diffable)
+  module Diff = Diffing.MakeVariadicLeft(Diffable)
 
   let diff env (l1,res1) (l2,_) =
     let param1 = Array.of_list l1 in
@@ -939,9 +939,7 @@ module Functor_app_diff = struct
             | Named _,  None | (Unit | Anonymous), Some _ -> 1
           end
 
-    let expand_params st =
-      let state, left, right = I.expand_params st in
-      state, right, left
+    let expand_params st = I.expand_params st
 
     let update (d: change) (st:state) =
       let open Error in
@@ -952,7 +950,7 @@ module Functor_app_diff = struct
       | Keep (_,Unit,_)
       | Change (_,(Unit | Named (None,_)), _ )
       | Change ((Unit,_), Named (Some _, _), _) ->
-          st, None, None
+          st, None
       | Keep ((Named arg,  _mty) , Named (param_name, _param), _)
       | Change ((Named arg, _mty), Named (param_name, _param), _) ->
           begin match param_name with
@@ -968,7 +966,7 @@ module Functor_app_diff = struct
               let subst = Subst.add_module param arg st.subst in
               expand_params { st with subst; res }
           | None ->
-              st, None, None
+              st, None
           end
       | Keep ((Anonymous, mty) , Named (param_name, _param), _)
       | Change ((Anonymous, mty), Named (param_name, _param), _) -> begin
@@ -981,7 +979,7 @@ module Functor_app_diff = struct
                 Option.map (Mtype.nondep_supertype env [param]) st.res in
               expand_params { st with env; res}
           | None ->
-              st, None, None
+              st, None
           end
         end
 
@@ -1002,7 +1000,7 @@ module Functor_app_diff = struct
       res
   end
 
-  module Diff = Diffing.Make(Diffable)
+  module Diff = Diffing.MakeVariadicRight(Diffable)
 
   let diff env ~f ~args =
     let params, res = retrieve_functor_params env f in

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -221,7 +221,7 @@ module Functor_inclusion_diff: sig
            Types.functor_parameter list * Types.module_type ->
            (Types.functor_parameter, Types.functor_parameter,
             Typedtree.module_coercion,
-            (Types.functor_parameter, 'c) Error.functor_param_symptom)
+            (Types.functor_parameter, unit) Error.functor_param_symptom)
            Diffing.patch
 end
 
@@ -232,6 +232,6 @@ module Functor_app_diff: sig
     args:(Error.functor_arg_descr * Types.module_type) list ->
     (Error.functor_arg_descr * Types.module_type,
      Types.functor_parameter, Typedtree.module_coercion,
-     (Error.functor_arg_descr, 'a) Error.functor_param_symptom)
+     (Error.functor_arg_descr, unit) Error.functor_param_symptom)
       Diffing.patch
 end

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -38,337 +38,346 @@ type ('left, 'right, 'eq, 'diff) change =
   | Keep of 'left * 'right * 'eq
   | Change of 'left * 'right * 'diff
 
-type ('l, 'r, 'eq, 'diff) patch = ('l, 'r, 'eq, 'diff) change list
+type ('left, 'right, 'eq, 'diff) patch = ('left, 'right, 'eq, 'diff) change list
 
-let map f g = function
-  | Delete x -> Delete (f x)
-  | Insert x -> Insert (g x)
-  | Keep (x,y,k) -> Keep (f x, g y, k)
-  | Change (x,y,k) -> Change (f x, g y, k)
+module type Diffable = sig
+  type left
+  type right
 
-type ('st,'left,'right) full_state = {
-  line: 'left array;
-  column: 'right array;
-  state: 'st
-}
+  type eq
+  type diff
 
-(* The matrix supporting our dynamic programming implementation.
+  (** The type of potential changes on a list. *)
+  type nonrec change = (left, right, eq, diff) change
 
-   Each cell contains:
-   - The diff and its weight
-   - The state computed so far
-   - The lists, potentially extended locally.
+  (** A patch is an ordered list of changes. *)
+  type patch = change list
 
-   The matrix can also be reshaped.
-*)
-module Matrix : sig
+  val weight : change -> int
 
-  type shape = { l : int ; c : int }
+  type state
 
-  type ('state,'left,'right,'eq,'diff) t
+  (** [test st xl xr] tests if the elements [xl] and [xr] are
+      compatible ([Ok]) or not ([Error]). *)
+  val test : state -> left -> right -> (eq, diff) result
 
-  val make : shape -> ('st,'l,'r,'e,'d) t
-  val reshape : shape -> ('st,'l,'r,'e,'d) t -> ('st,'l,'r,'e,'d) t
+  (** [update change state] return the new state after applying a change.
 
-  (** accessor functions *)
-  val diff : (_,'l,'r,'e,'d) t -> int -> int -> ('l,'r,'e,'d) change option
-  val state :
-    ('st,'l,'r,'e,'d) t -> int -> int -> ('st, 'l, 'r) full_state option
-  val weight : _ t -> int -> int -> int
-
-  val line : (_,'l,_,_,_) t -> int -> int -> 'l option
-  val column : (_,_,'r,_,_) t -> int -> int -> 'r option
-
-  val set :
-    ('st,'l,'r,'e,'d) t -> int -> int ->
-    diff:('l,'r,'e,'d) change option ->
-    weight:int ->
-    state:('st, 'l, 'r) full_state ->
-    unit
-
-  (** the shape when starting filling the matrix *)
-  val shape : _ t -> shape
-
-  (** [shape m i j] is the shape as seen from the state at position (i,j)
-      after some possible extensions
-  *)
-  val shape_at : _ t -> int -> int -> shape option
-
-  (** the maximal shape on the whole matrix *)
-  val real_shape : _ t -> shape
-
-  (** debugging printer *)
-  val[@warning "-32"] pp : Format.formatter -> _ t -> unit
-
-end = struct
-
-  type shape = { l : int ; c : int }
-
-  type ('state,'left,'right,'eq,'diff) t =
-    { states: ('state,'left,'right) full_state option array array;
-      weight: int array array;
-      diff: ('left,'right,'eq,'diff) change option array array;
-      columns: int;
-      lines: int;
-    }
-  let opt_get a n =
-    if n < Array.length a then Some (Array.unsafe_get a n) else None
-  let line m i j = let* st = m.states.(i).(j) in opt_get st.line i
-  let column m i j = let* st = m.states.(i).(j) in opt_get st.column j
-  let diff m i j = m.diff.(i).(j)
-  let weight m i j = m.weight.(i).(j)
-  let state m i j = m.states.(i).(j)
-  let shape m = { l = m.lines ; c = m.columns }
-
-  let set m i j ~diff ~weight ~state =
-    m.weight.(i).(j) <- weight;
-    m.states.(i).(j) <- Some state;
-    m.diff.(i).(j) <- diff;
-    ()
-
-  let shape_at tbl i j =
-    let+ st = tbl.states.(i).(j) in
-    let l = Array.length st.line in
-    let c = Array.length st.column in
-    { l ; c }
-
-  let real_shape tbl =
-    let lines = ref tbl.lines in
-    let columns = ref tbl.columns in
-    for i = 0 to tbl.lines do
-      for j = 0 to tbl.columns do
-        let*! {l; c} = shape_at tbl i j in
-        if l > !lines then lines := l;
-        if c > !columns then columns := c
-      done;
-    done;
-    { l = !lines ; c = !columns }
-
-  let make { l = lines ; c = columns } =
-    { states = Array.make_matrix (lines + 1) (columns + 1) None;
-      weight = Array.make_matrix (lines + 1) (columns + 1) max_int;
-      diff = Array.make_matrix (lines + 1) (columns + 1) None;
-      lines;
-      columns;
-    }
-
-  let reshape { l = lines ; c = columns } m =
-    let copy default a =
-      Array.init (1+lines) (fun i -> Array.init (1+columns) (fun j ->
-          if i <= m.lines && j <= m.columns then
-            a.(i).(j)
-          else default) ) in
-    { states = copy None m.states;
-      weight = copy max_int m.weight;
-      diff = copy None m.diff;
-      lines;
-      columns
-    }
-
-  let pp ppf m =
-    let { l ; c } = shape m in
-    Format.eprintf "Shape : %i, %i@." l c;
-    for i = 0 to l do
-      for j = 0 to c do
-        let d = diff m i j in
-        match d with
-        | None ->
-            Format.fprintf ppf "    "
-        | Some diff ->
-            let sdiff = match diff with
-              | Insert _ -> "\u{2190}"
-              | Delete _ -> "\u{2191}"
-              | Keep _ -> "\u{2196}"
-              | Change _ -> "\u{21F1}"
-            in
-            let w = weight m i j in
-            Format.fprintf ppf "%s%i " sdiff w
-      done;
-      Format.pp_print_newline ppf ()
-    done
-
+     We support variadic diffing: dynamically extending the lists to
+     diff depending on the placement choices for a prefix of the
+     input. This is done by returning (optional) extensions for the
+     left or right input array. *)
+  val update : change -> state -> state * left array option * right array option
 end
 
-(* Computation of new cells *)
+module Make (T : Diffable) = struct
+  open T
 
-let select_best_proposition l =
-  let compare_proposition curr prop =
-    match curr, prop with
-    | None, o | o, None -> o
-    | Some (curr_m, curr_res), Some (m, res) ->
-        Some (if curr_m <= m then curr_m, curr_res else m,res)
-  in
-  List.fold_left compare_proposition None l
+  type full_state = {
+    line: left array;
+    column: right array;
+    state: state;
+  }
 
-(* Boundary cell update *)
-let compute_column0 ~weight ~update tbl i =
-  let*! st = Matrix.state tbl (i-1) 0 in
-  let*! line = Matrix.line tbl (i-1) 0 in
-  let diff = Delete line in
-  Matrix.set tbl i 0
-    ~weight:(weight diff + Matrix.weight tbl (i-1) 0)
-    ~state:(update diff st)
-    ~diff:(Some diff)
+  let weight = T.weight
 
-let compute_line0 ~weight ~update tbl j =
-  let*! st = Matrix.state tbl 0 (j-1) in
-  let*! column = Matrix.column tbl 0 (j-1) in
-  let diff = Insert column in
-  Matrix.set tbl 0 j
-    ~weight:(weight diff + Matrix.weight tbl 0 (j-1))
-    ~state:(update diff st)
-    ~diff:(Some diff)
+  let test = T.test
 
-let compute_inner_cell ~weight ~test ~update tbl i j =
-  let compute_proposition i j diff =
-    let* diff = diff in
-    let+ localstate = Matrix.state tbl i j in
-    weight diff + Matrix.weight tbl i j, (diff, localstate)
-  in
-  let del =
-    let diff = let+ x = Matrix.line tbl (i-1) j in Delete x in
-    compute_proposition (i-1) j diff
-  in
-  let insert =
-    let diff = let+ x = Matrix.column tbl i (j-1) in Insert x in
-    compute_proposition i (j-1) diff
-  in
-  let diag =
-    let diff =
-      let* state = Matrix.state tbl (i-1) (j-1) in
-      let* line = Matrix.line tbl (i-1) (j-1) in
-      let* column = Matrix.column tbl (i-1) (j-1) in
-      match test state.state line column with
-      | Ok ok -> Some (Keep (line, column, ok))
-      | Error err -> Some (Change (line, column, err))
-    in
-    compute_proposition (i-1) (j-1) diff
-  in
-  let*! newweight, (diff, localstate) =
-    select_best_proposition [diag;del;insert]
-  in
-  let state = update diff localstate in
-  Matrix.set tbl i j ~weight:newweight ~state ~diff:(Some diff)
+  let update d { state; line; column } =
+    let may_append x = function
+      | None | Some [||] -> x
+      | Some y -> Array.append x y in
+    let state, dline, dcolumn = T.update d state in
+    let line = may_append line dline in
+    let column = may_append column dcolumn in
+    { state; line; column }
 
-let compute_cell ~weight ~test ~update m i j =
-  match i, j with
-  | _ when Matrix.diff m i j <> None -> ()
-  | 0,0 -> ()
-  | 0,j -> compute_line0 ~update ~weight m j
-  | i,0 -> compute_column0 ~update ~weight m i;
-  | _ -> compute_inner_cell ~weight ~test ~update m i j
+  (* The matrix supporting our dynamic programming implementation.
 
-(* Filling the matrix
+     Each cell contains:
+     - The diff and its weight
+     - The state computed so far
+     - The lists, potentially extended locally.
 
-   We fill the whole matrix, as in vanilla Wagner-Fischer.
-   At this point, the lists in some states might have been extended.
-   If any list have been extended, we need to reshape the matrix
-   and repeat the process
-*)
-let compute_matrix ~weight ~test ~update state0 =
-  let m0 = Matrix.make { l = 0 ; c = 0 } in
-  Matrix.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
-  let rec loop m =
-    let shape = Matrix.shape m in
-    let new_shape = Matrix.real_shape m in
-    if new_shape.l > shape.l || new_shape.c > shape.c then
-      let m = Matrix.reshape new_shape m in
-      for i = 0 to new_shape.l do
-        for j = 0 to new_shape.c do
-          compute_cell ~update ~test ~weight m i j
-        done
+     The matrix can also be reshaped.
+  *)
+  module Matrix : sig
+
+    type shape = { l : int ; c : int }
+
+    type t
+
+    val make : shape -> t
+    val reshape : shape -> t -> t
+
+    (** accessor functions *)
+    val diff : t -> int -> int -> change option
+    val state : t -> int -> int -> full_state option
+    val weight : t -> int -> int -> int
+
+    val line : t -> int -> int -> left option
+    val column : t -> int -> int -> right option
+
+    val set :
+      t -> int -> int ->
+      diff:change option ->
+      weight:int ->
+      state:full_state ->
+      unit
+
+    (** the shape when starting filling the matrix *)
+    val shape : t -> shape
+
+    (** [shape m i j] is the shape as seen from the state at position (i,j)
+        after some possible extensions
+    *)
+    val shape_at : t -> int -> int -> shape option
+
+    (** the maximal shape on the whole matrix *)
+    val real_shape : t -> shape
+
+    (** debugging printer *)
+    val[@warning "-32"] pp : Format.formatter -> t -> unit
+
+  end = struct
+
+    type shape = { l : int ; c : int }
+
+    type t =
+      { states: full_state option array array;
+        weight: int array array;
+        diff: change option array array;
+        columns: int;
+        lines: int;
+      }
+    let opt_get a n =
+      if n < Array.length a then Some (Array.unsafe_get a n) else None
+    let line m i j = let* st = m.states.(i).(j) in opt_get st.line i
+    let column m i j = let* st = m.states.(i).(j) in opt_get st.column j
+    let diff m i j = m.diff.(i).(j)
+    let weight m i j = m.weight.(i).(j)
+    let state m i j = m.states.(i).(j)
+    let shape m = { l = m.lines ; c = m.columns }
+
+    let set m i j ~diff ~weight ~state =
+      m.weight.(i).(j) <- weight;
+      m.states.(i).(j) <- Some state;
+      m.diff.(i).(j) <- diff;
+      ()
+
+    let shape_at tbl i j =
+      let+ st = tbl.states.(i).(j) in
+      let l = Array.length st.line in
+      let c = Array.length st.column in
+      { l ; c }
+
+    let real_shape tbl =
+      let lines = ref tbl.lines in
+      let columns = ref tbl.columns in
+      for i = 0 to tbl.lines do
+        for j = 0 to tbl.columns do
+          let*! {l; c} = shape_at tbl i j in
+          if l > !lines then lines := l;
+          if c > !columns then columns := c
+        done;
       done;
-      loop m
-    else
-      m
-  in
-  loop m0
+      { l = !lines ; c = !columns }
 
-(* Building the patch.
+    let make { l = lines ; c = columns } =
+      { states = Array.make_matrix (lines + 1) (columns + 1) None;
+        weight = Array.make_matrix (lines + 1) (columns + 1) max_int;
+        diff = Array.make_matrix (lines + 1) (columns + 1) None;
+        lines;
+        columns;
+      }
 
-   We first select the best final cell. A potential final cell
-   is a cell where the local shape (i.e., the size of the strings) correspond
-   to its position in the matrix. In other words: it's at the end of both its
-   strings. We select the final cell with the smallest weight.
+    let reshape { l = lines ; c = columns } m =
+      let copy default a =
+        Array.init (1+lines) (fun i -> Array.init (1+columns) (fun j ->
+            if i <= m.lines && j <= m.columns then
+              a.(i).(j)
+            else default) ) in
+      { states = copy None m.states;
+        weight = copy max_int m.weight;
+        diff = copy None m.diff;
+        lines;
+        columns
+      }
 
-   We then build the patch by walking backward from the final cell to the
-   origin.
-*)
+    let pp ppf m =
+      let { l ; c } = shape m in
+      Format.eprintf "Shape : %i, %i@." l c;
+      for i = 0 to l do
+        for j = 0 to c do
+          let d = diff m i j in
+          match d with
+          | None ->
+              Format.fprintf ppf "    "
+          | Some diff ->
+              let sdiff = match diff with
+                | Insert _ -> "\u{2190}"
+                | Delete _ -> "\u{2191}"
+                | Keep _ -> "\u{2196}"
+                | Change _ -> "\u{21F1}"
+              in
+              let w = weight m i j in
+              Format.fprintf ppf "%s%i " sdiff w
+        done;
+        Format.pp_print_newline ppf ()
+      done
 
-let select_final_state m0 =
-  let maybe_final i j =
-    match Matrix.shape_at m0 i j with
-    | Some shape_here -> shape_here.l = i && shape_here.c = j
-    | None -> false
-  in
-  let best_state (i0,j0,weigth0) (i,j) =
-    let weight = Matrix.weight m0 i j in
-    if weight < weigth0 then (i,j,weight) else (i0,j0,weigth0)
-  in
-  let res = ref (0,0,max_int) in
-  let shape = Matrix.shape m0 in
-  for i = 0 to shape.l do
-    for j = 0 to shape.c do
-      if maybe_final i j then
-        res := best_state !res (i,j)
-    done
-  done;
-  let i_final, j_final, _ = !res in
-  assert (i_final <> 0 || j_final <> 0);
-  (i_final, j_final)
+  end
 
-let construct_patch m0 =
-  let rec aux acc (i, j) =
-    if i = 0 && j = 0 then
-      acc
-    else
-      match Matrix.diff m0 i j with
-      | None -> assert false
-      | Some d ->
-          let next = match d with
-            | Keep _ | Change _ -> (i-1, j-1)
-            | Delete _ -> (i-1, j)
-            | Insert _ -> (i, j-1)
-          in
-          aux (d::acc) next
-  in
-  aux [] (select_final_state m0)
+  (* Computation of new cells *)
 
-let diff ~weight ~test ~update state line column =
-  let update d fs = { fs with state = update d fs.state } in
-  let fullstate = { line; column; state } in
-  compute_matrix ~weight ~test ~update fullstate
-  |> construct_patch
+  let select_best_proposition l =
+    let compare_proposition curr prop =
+      match curr, prop with
+      | None, o | o, None -> o
+      | Some (curr_m, curr_res), Some (m, res) ->
+          Some (if curr_m <= m then curr_m, curr_res else m,res)
+    in
+    List.fold_left compare_proposition None l
 
-type ('l, 'r, 'e, 'd, 'state) update =
-  | Without_extensions of (('l,'r,'e,'d) change -> 'state -> 'state)
-  | With_left_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'l array)
-  | With_right_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'r array)
+  (* Boundary cell update *)
+  let compute_column0 tbl i =
+    let*! st = Matrix.state tbl (i-1) 0 in
+    let*! line = Matrix.line tbl (i-1) 0 in
+    let diff = Delete line in
+    Matrix.set tbl i 0
+      ~weight:(weight diff + Matrix.weight tbl (i-1) 0)
+      ~state:(update diff st)
+      ~diff:(Some diff)
 
-let variadic_diff ~weight ~test ~(update:_ update) state line column =
-  let may_append x = function
-    | [||] -> x
-    | y -> Array.append x y in
-  let update = match update with
-    | Without_extensions up ->
-        fun d fs ->
-          let state = up d fs.state in
-          { fs with state }
-    | With_left_extensions up ->
-        fun d fs ->
-          let state, a = up d fs.state in
-          { fs with state ; line = may_append fs.line a }
-    | With_right_extensions up ->
-        fun d fs ->
-          let state, a = up d fs.state in
-          { fs with state ; column = may_append fs.column a }
-  in
-  let fullstate = { line; column; state } in
-  compute_matrix ~weight ~test ~update fullstate
-  |> construct_patch
+  let compute_line0 tbl j =
+    let*! st = Matrix.state tbl 0 (j-1) in
+    let*! column = Matrix.column tbl 0 (j-1) in
+    let diff = Insert column in
+    Matrix.set tbl 0 j
+      ~weight:(weight diff + Matrix.weight tbl 0 (j-1))
+      ~state:(update diff st)
+      ~diff:(Some diff)
 
+  let compute_inner_cell tbl i j =
+    let compute_proposition i j diff =
+      let* diff = diff in
+      let+ localstate = Matrix.state tbl i j in
+      weight diff + Matrix.weight tbl i j, (diff, localstate)
+    in
+    let del =
+      let diff = let+ x = Matrix.line tbl (i-1) j in Delete x in
+      compute_proposition (i-1) j diff
+    in
+    let insert =
+      let diff = let+ x = Matrix.column tbl i (j-1) in Insert x in
+      compute_proposition i (j-1) diff
+    in
+    let diag =
+      let diff =
+        let* state = Matrix.state tbl (i-1) (j-1) in
+        let* line = Matrix.line tbl (i-1) (j-1) in
+        let* column = Matrix.column tbl (i-1) (j-1) in
+        match test state.state line column with
+        | Ok ok -> Some (Keep (line, column, ok))
+        | Error err -> Some (Change (line, column, err))
+      in
+      compute_proposition (i-1) (j-1) diff
+    in
+    let*! newweight, (diff, localstate) =
+      select_best_proposition [diag;del;insert]
+    in
+    let state = update diff localstate in
+    Matrix.set tbl i j ~weight:newweight ~state ~diff:(Some diff)
+
+  let compute_cell m i j =
+    match i, j with
+    | _ when Matrix.diff m i j <> None -> ()
+    | 0,0 -> ()
+    | 0,j -> compute_line0 m j
+    | i,0 -> compute_column0 m i;
+    | _ -> compute_inner_cell m i j
+
+  (* Filling the matrix
+
+     We fill the whole matrix, as in vanilla Wagner-Fischer.
+     At this point, the lists in some states might have been extended.
+     If any list have been extended, we need to reshape the matrix
+     and repeat the process
+  *)
+  let compute_matrix state0 =
+    let m0 = Matrix.make { l = 0 ; c = 0 } in
+    Matrix.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
+    let rec loop m =
+      let shape = Matrix.shape m in
+      let new_shape = Matrix.real_shape m in
+      if new_shape.l > shape.l || new_shape.c > shape.c then
+        let m = Matrix.reshape new_shape m in
+        for i = 0 to new_shape.l do
+          for j = 0 to new_shape.c do
+            compute_cell m i j
+          done
+        done;
+        loop m
+      else
+        m
+    in
+    loop m0
+
+  (* Building the patch.
+
+     We first select the best final cell. A potential final cell
+     is a cell where the local shape (i.e., the size of the strings) correspond
+     to its position in the matrix. In other words: it's at the end of both its
+     strings. We select the final cell with the smallest weight.
+
+     We then build the patch by walking backward from the final cell to the
+     origin.
+  *)
+
+  let select_final_state m0 =
+    let maybe_final i j =
+      match Matrix.shape_at m0 i j with
+      | Some shape_here -> shape_here.l = i && shape_here.c = j
+      | None -> false
+    in
+    let best_state (i0,j0,weigth0) (i,j) =
+      let weight = Matrix.weight m0 i j in
+      if weight < weigth0 then (i,j,weight) else (i0,j0,weigth0)
+    in
+    let res = ref (0,0,max_int) in
+    let shape = Matrix.shape m0 in
+    for i = 0 to shape.l do
+      for j = 0 to shape.c do
+        if maybe_final i j then
+          res := best_state !res (i,j)
+      done
+    done;
+    let i_final, j_final, _ = !res in
+    assert (i_final <> 0 || j_final <> 0);
+    (i_final, j_final)
+
+  let construct_patch m0 =
+    let rec aux acc (i, j) =
+      if i = 0 && j = 0 then
+        acc
+      else
+        match Matrix.diff m0 i j with
+        | None -> assert false
+        | Some d ->
+            let next = match d with
+              | Keep _ | Change _ -> (i-1, j-1)
+              | Delete _ -> (i-1, j)
+              | Insert _ -> (i, j-1)
+            in
+            aux (d::acc) next
+    in
+    aux [] (select_final_state m0)
+
+  let diff state line column =
+    { state; line; column }
+    |> compute_matrix
+    |> construct_patch
+  end
 
 type change_kind =
   | Deletion
@@ -393,9 +402,3 @@ let prefix ppf (pos, p) =
   Format.pp_open_stag ppf (Misc.Color.Style sty);
   Format.fprintf ppf "%i. " pos;
   Format.pp_close_stag ppf ()
-
-  let default_weight = function
-    | Insert _ -> 10
-    | Delete _ -> 10
-    | Change _ -> 10
-    | Keep _ -> 0

--- a/utils/diffing_with_keys.ml
+++ b/utils/diffing_with_keys.ml
@@ -195,7 +195,6 @@ module Make (T : Diffable_with_keys) = struct
         include T
         type left = keyed_left
         type right = keyed_right
-        let update d st = update d st, None, None
       end)
     in
     Diff.diff state (with_pos line) (with_pos column)

--- a/utils/diffing_with_keys.mli
+++ b/utils/diffing_with_keys.mli
@@ -32,12 +32,12 @@
 type 'a with_pos = int * 'a
 val with_pos: 'a list -> 'a with_pos list
 
-type ('a,'b) mismatch =
+type ('a, 'tdiff) mismatch =
   | Name of {pos:int; got:string; expected:string; types_match:bool}
-  | Type of {pos:int; got:'a; expected:'a; reason:'b}
+  | Type of {pos:int; got:'a; expected:'a; reason:'tdiff}
 
-type ('a,'b) change =
-  | Change of ('a,'b) mismatch
+type ('a, 'tdiff) change =
+  | Change of ('a, 'tdiff) mismatch
   | Swap of { pos: int * int; first: string; last: string }
   | Move of {name:string; got:int; expected:int}
   | Insert of {pos:int; insert:'a}
@@ -46,9 +46,9 @@ type ('a,'b) change =
 val refine:
   key:('a -> string) ->
   update:('ch -> 'state -> 'state) ->
-  test:('state -> 'a with_pos -> 'a with_pos -> (_, _) result) ->
+  test:('state -> 'a with_pos -> 'a with_pos -> (unit,  ('a, 'tdiff) mismatch) result) ->
   'state ->
-  (('a with_pos,'a with_pos,_,('a,'b) mismatch) Diffing.change as 'ch) list ->
-  ('a, 'b) change list
+  (('a with_pos,'a with_pos, unit, ('a, 'tdiff) mismatch) Diffing.change as 'ch) list ->
+  ('a, 'tdiff) change list
 
 val prefix: Format.formatter -> ('a,'b) change -> unit

--- a/utils/diffing_with_keys.mli
+++ b/utils/diffing_with_keys.mli
@@ -32,23 +32,25 @@
 type 'a with_pos = int * 'a
 val with_pos: 'a list -> 'a with_pos list
 
-type ('a, 'tdiff) mismatch =
+type ('l, 'r, 'tdiff) mismatch =
   | Name of {pos:int; got:string; expected:string; types_match:bool}
-  | Type of {pos:int; got:'a; expected:'a; reason:'tdiff}
+  | Type of {pos:int; got:'l; expected:'r; reason:'tdiff}
 
-type ('a, 'tdiff) change =
-  | Change of ('a, 'tdiff) mismatch
-  | Swap of { pos: int * int; first: string; last: string }
+type ('l, 'r, 'tdiff) change =
+  | Change of ('l, 'r, 'tdiff) mismatch
+  | Swap of {pos: int * int; first: string; last: string}
   | Move of {name:string; got:int; expected:int}
-  | Insert of {pos:int; insert:'a}
-  | Delete of {pos:int; delete:'a}
+  | Delete of {pos:int; delete:'l}
+  | Insert of {pos:int; insert:'r}
+
+type ('l, 'r) keys = ('l -> string) * ('r -> string)
 
 val refine:
-  key:('a -> string) ->
+  key:(('l, 'r) keys) ->
   update:('ch -> 'state -> 'state) ->
-  test:('state -> 'a with_pos -> 'a with_pos -> (unit,  ('a, 'tdiff) mismatch) result) ->
+  test:('state -> 'l with_pos -> 'r with_pos -> (unit, ('l, 'r, 'tdiff) mismatch) result) ->
   'state ->
-  (('a with_pos,'a with_pos, unit, ('a, 'tdiff) mismatch) Diffing.change as 'ch) list ->
-  ('a, 'tdiff) change list
+  (('l with_pos, 'r with_pos, unit, ('l, 'r, 'tdiff) mismatch) Diffing.change as 'ch) list ->
+  ('l, 'r, 'tdiff) change list
 
-val prefix: Format.formatter -> ('a,'b) change -> unit
+val prefix: Format.formatter -> ('l, 'r, 'tdiff) change -> unit


### PR DESCRIPTION
This PR is on top of #2. I wrote it as an integrable proof-of-concept: ~~if @Octachron agrees that this makes the code nicer, ideally he would be willing to finish the job by also functorizing Diffing_with_keys on his own~~. I now implemented functorization for both `Diffing` and `Diffing_with_keys`, completing the change I had in mind.