### PR TITLE
Test NFD normalized unit names

### DIFF
--- a/testsuite/tests/typing-unicode/genfiles.ml
+++ b/testsuite/tests/typing-unicode/genfiles.ml
@@ -1,8 +1,8 @@
 let create_file name contents =
   Out_channel.with_open_text name (fun oc -> output_string oc contents)
 
-(* File names in NFC *)
-
 let _ =
+  (* File name in NFC *)
   create_file "été.ml" "let x = 1\n";
-  create_file "ça.ml"  "let x = 2\n"
+  (* File name in NFD *)
+  create_file "\u{0063}\u{0327}a.ml"  "let x = 2\n"

--- a/testsuite/tests/typing-unicode/test.ml
+++ b/testsuite/tests/typing-unicode/test.ml
@@ -5,11 +5,14 @@ all_modules = "genfiles.ml";
 program = "./genfiles.byte.exe";
 ocamlc.byte;
 run;
-all_modules = "été.ml ça.ml test.ml";
+all_modules = "été.ml ça.ml test.ml";
 program = "./main.byte.exe";
 ocamlc.byte;
 run;
 *)
 
 let _ =
-  assert (Été.x + Ça.x = 3)
+  (* Source is NFC *)
+  assert (Été.x + Ça.x = 3);
+  (* Source is NFD *)
+  assert (Été.x + Ça.x = 3)


### PR DESCRIPTION
The filename ça.ml is NFD normalized. The test source now the two normalizations for each unit identifiers.